### PR TITLE
fix: invalid nfd tag version

### DIFF
--- a/images.yaml
+++ b/images.yaml
@@ -41,7 +41,7 @@ docker.io/projecthami/volcano-vgpu-device-plugin:/^v((1\.(9\.\d+|[1-9]\d+\.\d+)|
 quay.io/kuberay/operator:/^v((1\.(2\.[0-9]+|[3-9]\.\d+|[1-9]\d+\.\d+)|[2-9]\d*\.\d+\.\d+|\d{2,}\.\d+\.\d+))$/:
   - llmos-ai-cn-beijing.cr.volces.com/llmos-ai/mirrored-kuberay-operator
   - ghcr.io/llmos-ai/mirrored-kuberay-operator
-registry.k8s.io/nfd/node-feature-discovery:/^(0\.(1[6-9]|[2-9]\d*)\.\d+|[1-9]\d*\.\d+\.\d+)$/:
+registry.k8s.io/nfd/node-feature-discovery:/^v((0\.(1[6-9]|[2-9]\d*)\.\d+|[1-9]\d*\.\d+\.\d+))$/:
   - llmos-ai-cn-beijing.cr.volces.com/llmos-ai/mirrored-nfd-node-feature-discovery
   - ghcr.io/llmos-ai/mirrored-nfd-node-feature-discovery
 registry.k8s.io/sig-storage/csi-attacher:/^v((4\.(6\.\d+|[7-9]\.\d+|[1-9]\d+\.\d+)|[5-9]\d*\.\d+\.\d+|\d{2,}\.\d+\.\d+))$/:


### PR DESCRIPTION
fix invalid node-feature-discovery tag version which now starts with `v*`